### PR TITLE
fix: --result returns the final review, not the raw session transcript

### DIFF
--- a/skills/fresheyes/fresheyes-progress.sh
+++ b/skills/fresheyes/fresheyes-progress.sh
@@ -264,6 +264,43 @@ cat_if_nonempty() {
   return 1
 }
 
+# GPT/Codex manual review logs hold the entire tee'd session transcript
+# (thousands of lines of commands and file reads); only the text from the
+# last "## Files Examined" header to EOF is the review itself. Claude logs
+# already contain only the final review text. Print the review, never the
+# raw transcript.
+print_final_review() {
+  local base="$1"
+  [[ -s "$base" ]] || return 1
+
+  local total start
+  total=$(LC_ALL=C wc -l < "$base" | tr -d '[:space:]')
+
+  # Small logs (Claude-provider results, short failure texts) are already
+  # just the final review; print them whole, as --result always did.
+  if (( total <= 400 )); then
+    cat "$base"
+    return 0
+  fi
+
+  # LC_ALL=C: macOS awk aborts mid-file on invalid multibyte sequences
+  # under UTF-8 locales, and codex transcripts can contain arbitrary bytes.
+  start=$(LC_ALL=C awk '/^## Files Examined/{n=NR} END{print n+0}' "$base" 2>/dev/null)
+
+  # The header also appears in the prompt echoed near the top of GPT
+  # transcripts; a match far from EOF is that echo, not the review. The
+  # real review section also carries a resolved verdict marker, which the
+  # echoed prompt template (bracketed "[PASSED/FAILED]") never does.
+  if [[ "$start" -gt 0 ]] && (( total - start < 500 )) \
+    && tail -n +"$start" "$base" | LC_ALL=C grep -Eq 'INDEPENDENT CODE REVIEW (PASSED|FAILED)'; then
+    tail -n +"$start" "$base"
+    return 0
+  fi
+  printf 'Fresh Eyes: could not isolate the final review section in a %s-line log; showing the last 120 lines to avoid dumping the raw session transcript. Full log: %s\n\n' "$total" "$base"
+  tail -n 120 "$base"
+  return 0
+}
+
 detect_manual_verdict() {
   local base="$1"
   if [[ ! -f "$base" ]]; then
@@ -582,7 +619,7 @@ print_result_or_pending() {
 
   case "$state" in
     complete)
-      if cat_if_nonempty "$base"; then
+      if print_final_review "$base"; then
         return 0
       fi
       print_failure_diagnostic "$base"

--- a/tests/fresheyes-progress-test.sh
+++ b/tests/fresheyes-progress-test.sh
@@ -438,6 +438,73 @@ TEXT
   assert_contains "$output" "INDEPENDENT CODE REVIEW PASSED" "global locator legacy override"
 }
 
+test_result_extracts_final_review_from_gpt_transcript() {
+  local pid base result
+  dead_pid pid
+  base="$LOG_DIR/fresheyes-test-$pid.log"
+  write_active "$pid" "$base"
+  # Reproduce the shape of a real detached GPT review log: run_gpt_manual tees
+  # the whole `codex exec` session into the log — banner, echoed prompt (which
+  # itself contains the "## Files Examined" output template), thousands of
+  # transcript lines — with the actual review only at the very end.
+  {
+    printf 'OpenAI Codex v0.0.0\nuser\nOutput template:\n## Files Examined\n## Issues Found\n'
+    for _ in $(seq 1 3000); do printf 'exec sed -n some/file transcript noise\n'; done
+    printf '## Files Examined\n- src/main.py\n\n## Issues Found\n- **major** src/main.py:10 - example\n\n## Summary\nExample.\n\n---\n**INDEPENDENT CODE REVIEW FAILED**\n'
+  } > "$base"
+
+  result=$(run_progress --result "$pid")
+  assert_contains "$result" "INDEPENDENT CODE REVIEW FAILED" "gpt transcript result verdict"
+  assert_contains "$result" "## Issues Found" "gpt transcript result findings"
+  assert_not_equals "$(printf '%s\n' "$result" | grep -c 'transcript noise')" "3000" "gpt transcript result excludes session transcript"
+  if (( $(printf '%s\n' "$result" | wc -l) > 100 )); then
+    fail "gpt transcript --result returned more than 100 lines; raw log leaked"
+  fi
+}
+
+test_result_caps_headerless_transcript() {
+  local pid base result
+  dead_pid pid
+  base="$LOG_DIR/fresheyes-test-$pid.log"
+  write_active "$pid" "$base"
+  # A review that never emitted its "## Files Examined" header: --result must
+  # not dump the transcript; it prints a capped tail that keeps the verdict.
+  {
+    for _ in $(seq 1 3000); do printf 'transcript noise\n'; done
+    printf '**INDEPENDENT CODE REVIEW PASSED**\n'
+  } > "$base"
+
+  result=$(run_progress --result "$pid")
+  assert_contains "$result" "INDEPENDENT CODE REVIEW PASSED" "headerless transcript verdict retained"
+  assert_contains "$result" "could not isolate the final review" "headerless transcript cap notice"
+  if (( $(printf '%s\n' "$result" | wc -l) > 150 )); then
+    fail "headerless transcript --result returned more than 150 lines; raw log leaked"
+  fi
+}
+
+test_result_keeps_preamble_in_small_review_logs() {
+  local pid base result
+  dead_pid pid
+  base="$LOG_DIR/fresheyes-test-$pid.log"
+  write_active "$pid" "$base"
+  # Claude-provider logs contain only the final review text, which may open
+  # with prose before the "## Files Examined" header. Small logs must print
+  # whole so that preamble is not lost.
+  cat > "$base" <<'TEXT'
+Summary first: the change looks correct overall.
+
+## Files Examined
+
+- README.md
+
+INDEPENDENT CODE REVIEW PASSED
+TEXT
+
+  result=$(run_progress --result "$pid")
+  assert_contains "$result" "Summary first" "small review log preamble retained"
+  assert_contains "$result" "INDEPENDENT CODE REVIEW PASSED" "small review log verdict"
+}
+
 test_alive_claude_sidecars_missing_log
 test_alive_claude_sidecars_empty_log
 test_legacy_no_pid_preserves_numeric_progress
@@ -453,5 +520,8 @@ test_dead_launcher_alias_to_live_owner_reports_running
 test_dead_launcher_alias_to_finished_owner_returns_review
 test_global_parent_alias_ignores_external_log_by_default
 test_global_locator_ignores_external_log_by_default
+test_result_extracts_final_review_from_gpt_transcript
+test_result_caps_headerless_transcript
+test_result_keeps_preamble_in_small_review_logs
 
 printf 'fresheyes-progress tests passed\n'


### PR DESCRIPTION
## Problem

For GPT/Codex manual reviews, `run_gpt_manual` tees the entire `codex exec` session into the log file (`fresheyes.sh:347`). The final-section extraction on the next line writes to stdout, which the detached child discards (`setsid bash "$0" ... >/dev/null 2>&1` at `fresheyes.sh:165`). `fresheyes-progress.sh --result` then `cat`s the whole log back to the calling agent.

Measured on five real reviews (gpt-5.5, xhigh): each `--result` returned 660KB–1MB (~165k–265k tokens) of transcript, with the actual review verdict in the last ~50 lines. Agent harnesses truncate large tool outputs from the tail, so the calling agent receives mostly transcript and can lose the verdict entirely — the opposite of what the SKILL.md contract ("Output the review response exactly as returned") intends.

The Claude provider is unaffected: its stream parser writes only the final result text to the log.

## Fix

`--result` routes through a new `print_final_review` in `fresheyes-progress.sh`:

- Logs of at most 400 lines print whole — Claude-provider results and short failure texts behave exactly as before, including reviews that open with prose before the header.
- Larger logs print from the last `## Files Examined` header to EOF (4–7KB on the same five reviews), but only when that section is near EOF (< 500-line remainder) and contains a resolved `INDEPENDENT CODE REVIEW PASSED/FAILED` marker. The prompt template echoed near the top of a codex transcript contains the header and only the bracketed `[PASSED/FAILED]` form, so it can never be selected.
- Anything else prints a capped 120-line tail plus the full log path. The verdict sits at EOF, so it survives the cap.
- The `awk`/`wc` calls run under `LC_ALL=C`: macOS awk aborts mid-file on invalid multibyte sequences in UTF-8 locales, and codex transcripts can contain arbitrary bytes.

Empty/missing-log handling is unchanged (`print_failure_diagnostic`), as are the `--json`, pending, and failed paths.

## Verification

- Three new regression tests reproduce the transcript shape (banner + echoed prompt + thousands of transcript lines + trailing review), the headerless-transcript cap, and the pre-header-preamble case. Full suite passes on Linux (`docker run python:3.12-slim` with `procps`): 18/18.
- Note: the suite does not currently run on macOS regardless of this change — the first legacy test compares BSD `wc -l` output, which is space-padded.
- Replayed against five real completed review logs: output went from 660KB–1MB of transcript to the exact 4–7KB review section ending with the verdict.

## Related observation (not addressed here)

Under `set -euo pipefail`, the discarded extraction pipeline `tac "$LOG_FILE" | sed '/^## Files Examined/q' | tac` (`fresheyes.sh:352`) exits 141 (SIGPIPE kills the first `tac`), so the detached child dies right after a successful GPT review and `status.json` records `state: failed, exit_code: 141`. Verdict-marker detection in `fresheyes-progress.sh` masks this, but the status file is wrong for every successful GPT manual review. With this PR the read side no longer depends on that pipeline; removing or hardening it could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)