### PR TITLE
fix: skip the codex git-repo trust check so GPT reviews run from any CWD

### DIFF
--- a/skills/fresheyes/fresheyes.sh
+++ b/skills/fresheyes/fresheyes.sh
@@ -553,8 +553,12 @@ CLAUDE_TOOLS='Bash(git diff:*,git show:*,git log:*,git status:*),Read,Glob,Grep'
 CLAUDE_STREAM_PARSER="$SCRIPT_DIR/fresheyes-claude-stream.py"
 
 run_gpt_manual() {
+  # --skip-git-repo-check: codex exec aborts when its working directory is not
+  # inside a git repo. Reviews run read-only and the scope names its own repo
+  # (often via `git -C`), so the caller's CWD must not gate the review.
   if ! "$CODEX_BIN" exec \
     --sandbox read-only \
+    --skip-git-repo-check \
     --color never \
     --model "$MODEL" \
     -c features.shell_snapshot=false \
@@ -576,6 +580,7 @@ run_gpt_automatic() {
   # Codex writes schema-conforming JSON directly to the output file — no post-processing needed.
   if ! "$CODEX_BIN" exec \
     --sandbox read-only \
+    --skip-git-repo-check \
     --color never \
     --model "$MODEL" \
     -c features.shell_snapshot=false \

--- a/tests/fresheyes-gpt-provider-test.sh
+++ b/tests/fresheyes-gpt-provider-test.sh
@@ -83,6 +83,8 @@ if "model_reasoning_effort=xhigh" not in argv:
     raise SystemExit(f"manual GPT review did not use xhigh reasoning: {argv!r}")
 if "-o" not in argv:
     raise SystemExit(f"manual GPT review did not request a last-message artifact: {argv!r}")
+if "--skip-git-repo-check" not in argv:
+    raise SystemExit(f"manual GPT review must skip the codex git-repo trust check: {argv!r}")
 PY
 
 if ! grep -q '^INDEPENDENT CODE REVIEW PASSED$' "$STDOUT_FILE"; then
@@ -182,6 +184,8 @@ if "model_reasoning_effort=medium" not in argv:
     raise SystemExit(f"automatic GPT review did not use medium reasoning: {argv!r}")
 if "--output-schema" not in argv or "-o" not in argv:
     raise SystemExit(f"automatic GPT review did not request structured output: {argv!r}")
+if "--skip-git-repo-check" not in argv:
+    raise SystemExit(f"automatic GPT review must skip the codex git-repo trust check: {argv!r}")
 PY
 
 if ! grep -q '^Fresh Eyes: approved\.$' "$AUTOMATIC_STDOUT_FILE"; then


### PR DESCRIPTION
## Symptom

`fresheyes.sh --gpt` fails in seconds (exit 1, two log lines) when launched from a directory that is not inside a git repository:

```
Reading additional input from stdin...
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

This is codex exec's trust check on its working directory. The `--claude` provider has no equivalent restriction, so the same scope reviewed fine with Claude — which makes the GPT failure look like a provider outage rather than a launch-directory issue.

## Why skipping the check is right here

- Reviews run under `--sandbox read-only`; the trust check exists to guard writes into untracked directories, which cannot happen here.
- The review scope names its own target repo (typically via `git -C /path/to/repo ...`), so the caller's CWD is irrelevant to what gets reviewed.
- Agent harnesses frequently launch reviews from workspace directories that are not git repos.

## Change

- Pass `--skip-git-repo-check` on both the manual and automatic `codex exec` invocations.
- Assert the flag in both argv checks in `tests/fresheyes-gpt-provider-test.sh`.

`tests/fresheyes-gpt-provider-test.sh`, `tests/fresheyes-verdict-test.sh`, and `tests/fresheyes-prompt-contract-test.sh` pass on macOS. (`fresheyes-claude-provider-test.sh`, `fresheyes-progress-test.sh`, and `fresheyes-detach-test.sh` fail identically on pristine `main` on macOS — setsid session semantics and BSD `wc` padding — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)